### PR TITLE
Fix why ember-command link on readme

### DIFF
--- a/ember-command/README.md
+++ b/ember-command/README.md
@@ -36,7 +36,8 @@ ember install ember-command
 ## Usage
 
 The idea for `ember-command` is clearly to [separate your business logic from
-your UI](../docs/why.md) by offering a couple of mechanics to do that.
+your UI](https://gossi.github.io/ember-command/why.html) by offering a couple of
+mechanics to do that.
 
 ### Actions
 


### PR DESCRIPTION
to make the link accessible from a couple of places: multiple GH folders, npm, etc.