### PR TITLE
Make `@command` arg optional

### DIFF
--- a/ember-command/src/components/command-element.gts
+++ b/ember-command/src/components/command-element.gts
@@ -14,7 +14,7 @@ import type { Link } from 'ember-link';
 interface CommandSignature<T extends string = 'span'> {
   Element: HTMLButtonElement | HTMLAnchorElement | ElementFromTagName<T>;
   Args: {
-    command: CommandAction;
+    command?: CommandAction;
     /**
      * Pass in a `(element)` as fallback when `@command` is empty. Anyway a `<span>`
      * is used.


### PR DESCRIPTION
... for the use-case when people provide an `undefined` (which is valid) - but then the types are failing. To prevent that, allow it to be optional.